### PR TITLE
all: make functional for HTTP POST request with JSON in headers + file body

### DIFF
--- a/cmd/tos3-server/README.md
+++ b/cmd/tos3-server/README.md
@@ -1,0 +1,38 @@
+## tos3-server
+
+The / endpoint expects an HTTP POST request with:
+
+* the file to be uploaded as the body of the POST request
+* "payload_json" as a header value with the JSON value of a Request, whose contents MUST be JSON serialized
+
+### Request
+
+Field name|Type/Validation|Required|Comment
+---|---|---|---
+private|boolean|No|If set will set the file permissions to private, so by default public files
+bucket|string|If not configured in the environment, should be accessible by the environment AWS credentials|
+path|string|Yes|the path offset from the bucket that'll finally appear in the URL
+name|string|Yes|representative name for the file
+
+If for example we ran the example in examples/upload_test.go or just sent this HTTP POST request
+```HTTP
+POST / HTTP/1.1
+Host: localhost:8833
+User-Agent: Go-http-client/1.1
+Transfer-Encoding: chunked
+Content-Type: file/octet-stream
+Payload_json: {"path":"926abe55d7ac4c8caa1cce89695650c5/profile_pic","name":"profile_pic"}
+Accept-Encoding: gzip
+```
+
+### Response
+This spits out this response
+
+```json
+{
+  "etag": "\"5b6c7b4aed837e8ed0f9950564a10b32\"",
+  "version_id": "73WpSQNRjQYhGWplXkml9Kz2HhcTJxr6",
+  "url": "https://tatan.s3.amazonaws.com/926abe55d7ac4c8caa1cce89695650c5/profile_pic",
+  "bucket": "tatan",
+  "name": "926abe55d7ac4c8caa1cce89695650c5/profile_pic"
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+## toS3 server 
+
+This example when used in combination with cmd/tos3-server/main.go will upload content to your Amazon S3 bucket and storage.
+
+TheIt can be configured

--- a/examples/upload_test.go
+++ b/examples/upload_test.go
@@ -1,0 +1,56 @@
+package example_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"os"
+
+	"github.com/orijtech/tos3"
+)
+
+func ExampleUploadFileToS3() {
+	f, err := os.Open(os.Getenv("TO_S3_UPLOAD_FILE"))
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	req, err := http.NewRequest("POST", "http://localhost:8833/", f)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Set("Content-Type", "file/octet-stream")
+	payloadBody := tos3.Request{
+		Path: "926abe55d7ac4c8caa1cce89695650c5/profile_pic",
+		Name: "profile_pic",
+	}
+	payloadJSON, err := json.Marshal(payloadBody)
+	if err != nil {
+		panic(err)
+	}
+	req.Header.Add("payload_json", string(payloadJSON))
+
+	reqBlob, err := httputil.DumpRequestOut(req, false)
+	if err != nil {
+		panic(err)
+	}
+	println(string(reqBlob))
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		panic(res.Status)
+	}
+	defer res.Body.Close()
+	blob, err := io.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	println(string(blob))
+	// Output:
+	//   This
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.14.6 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/orijtech/otils v0.0.2 // indirect
 	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/odeke-em/go-uuid v0.0.0-20151221120446-b211d769a9aa h1:XEhClAZN5U0GUT
 github.com/odeke-em/go-uuid v0.0.0-20151221120446-b211d769a9aa/go.mod h1:omlfAqAAOXYL53jxw8wG+G2xH7NqbkJPlDeGP9YpP6g=
 github.com/odeke-em/tmpfile v0.0.0-20160613075305-c3f30bc34d6a h1:o3rLG0VXHww2o86LYg9HZjEM6qeZ7VUtrQRi3yndSUo=
 github.com/odeke-em/tmpfile v0.0.0-20160613075305-c3f30bc34d6a/go.mod h1:Udn2PRbvC0hxOjzIuoGzWkqztUW9alTudGqi4CNfjtM=
+github.com/orijtech/otils v0.0.2 h1:nbdAT171Xo98hOEmfWkuxWnNgoyNscnGMd5YnrXzblg=
+github.com/orijtech/otils v0.0.2/go.mod h1:ptnjhGLL7nB/n55+7NbDs96aFkZHtmj4PCFsgG6aac8=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
This change modifies the server to make it simple to use
for forwarding over requests to make uploads, whereby the
body of the HTTP POST request will be the entire file, the HTTP
headers will contain the JSON payload of the tos3.Request

* Request
```HTTP
POST / HTTP/1.1
Host: localhost:8833
User-Agent: Go-http-client/1.1
Transfer-Encoding: chunked
Content-Type: file/octet-stream
Payload_json: {"path":"926abe55d7ac4c8caa1cce89695650c5/profile_pic","name":"profile_pic"}
Accept-Encoding: gzip
```

* Response
```HTTP
{
  "etag": "\"5b6c7b4aed837e8ed0f9950564a10b32\"",
  "version_id": "73WpSQNRjQYhGWplXkml9Kz2HhcTJxr6",
  "url": "https://tatan.s3.amazonaws.com/926abe55d7ac4c8caa1cce89695650c5/profile_pic",
  "bucket": "tatan",
  "name": "926abe55d7ac4c8caa1cce89695650c5/profile_pic"
}
```

and provided a functional end-to-end example in examples/upload_test.go
which can be run by `go test example/upload_test.go`