### PR TITLE
all: use traced HTTP clients for continuity for until data gets uploaded

### DIFF
--- a/cmd/tos3-server/main.go
+++ b/cmd/tos3-server/main.go
@@ -50,9 +50,11 @@ func pathOf(req *tos3.Request) string {
 	return path
 }
 
+var tracedHTTPClient = &http.Client{Transport: &ochttp.Transport{}}
+
 func init() {
 	envCred := credentials.NewEnvCredentials()
-	config := aws.NewConfig().WithCredentials(envCred)
+	config := aws.NewConfig().WithCredentials(envCred).WithHTTPClient(tracedHTTPClient)
 	sess := session.Must(session.NewSession(config))
 	s3Client = s3.New(sess)
 }
@@ -156,7 +158,7 @@ func uploadIt(rw http.ResponseWriter, req *http.Request) {
 
 func main() {
 	var port int
-	ocAgentAddress := flag.String("ocagent-addr", "", "The address to connect to the OpenCensus/Telemetry CAgent")
+	ocAgentAddress := flag.String("ocagent-addr", "", "The address to connect to the OpenCensus/Telemetry OCAgent")
 	flag.IntVar(&port, "port", 8833, "the port to run it on")
 	flag.StringVar(&defaultBucket, "default-bucket", "tatan", "the default bucket to use")
 	flag.StringVar(&defaultPath, "common-io", "tatan", "the default path to use")

--- a/tos3.go
+++ b/tos3.go
@@ -152,7 +152,7 @@ func (req *Request) FUploadToS3(ctx context.Context, body io.ReadSeeker) (_ *Res
 		pin.ContentLength = &req.ContentLength
 	}
 
-	pout, err := req.S3Client.PutObject(pin)
+	pout, err := req.S3Client.PutObjectWithContext(ctx, pin)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Ensures that the traces are connected and uploaded successfully, even
from the AWS S3 library internals.

This results then in
![Screen Shot 2022-08-14 at 2 14 04 PM](https://user-images.githubusercontent.com/4898263/184555244-c2f4113d-0efd-4fae-869e-9907872cb0f2.png)
